### PR TITLE
feat: add mistral endpoit for the finetuned logo generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # fudeno
+
+Required env variables:
+
+```
+ANTHROPIC_API_KEY=
+ANTHROPIC_MODEL=
+ANTHROPIC_MODEL_LOGO=
+MISTRAL_AGENT_MODEL=
+MISTRAL_API_KEY=
+```

--- a/frontend/app/api/logo/route.ts
+++ b/frontend/app/api/logo/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import { Mistral } from "@mistralai/mistralai";
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
+});
+
+const mistral = new Mistral({
+  apiKey: process.env.MISTRAL_API_KEY,
 });
 
 export async function POST(request: Request) {
@@ -41,29 +46,44 @@ export async function POST(request: Request) {
 
     console.log("Logo Generation Prompt:", logoPrompt);
 
+    // Anthropic API request
     const logoMessage = await anthropic.messages.create({
       model: process.env.ANTHROPIC_MODEL_LOGO,
       max_tokens: 500,
       temperature: 1,
       system:
         "you are a vector logo designer that creates simple and minimal logos and designs based on the user's business.\n\n- do not use paths\n- do not use polygons\n- do not try to make art\n- focus on typography\n- only respond with the <text></text>\n- experiment with the text rendering for unique designs",
-
       messages: [
         {
           role: "user",
           content: [
             {
               type: "text",
-              text: `${logoPrompt}, please reflect on your design as you write it to ensure its accuracy in design.\n\n\nYou follow these rules:\n- always start with <svg xmlns=\"http://www.w3.org/2000/svg\" width=\"512\" height=\"512\" viewBox=\"0 0 512 512\">\n- if you use text you never use paths to create the text you use a <text></text> element and you only write one line of text like \"Apple\", no taglines.\n- logos are always centered and take up 90% of the viewport\n- follow good simple design processes\n- you only respond with the SVG code\n- you never use code blocks\n- I don't want vector paths or polygons, only text\n- you leave the backgrounds transparent`,
+              text: `${logoPrompt}, please reflect on your design as you write it to ensure its accuracy in design.\n\n\nYou follow these rules:\n- always start with <svg xmlns=\"http://www.w3.org/2000/svg\" width=\"512\" height=\"512\" viewBox=\"0 0 512 512\">\n- if you use text you never use paths to create the text you use a <text></text> element and you only write one line of text like \"Apple\", no taglines.\n- logos are always centered and take up 90% of the viewport\n- follow good simple design processes\n- you only respond with the SVG code\n- you never use code blocks\n- I don't want vector paths or polygons, only text\n- you leave the backgrounds transparent\n- you will only output <text></text> elements in the SVG and nothing else.`,
             },
           ],
         },
       ],
     });
 
-    console.log("Logo API Raw Response:", logoMessage);
+    // Mistral Agent API request
+    const mistralResponse = await mistral.agents.complete({
+      agentId: process.env.MISTRAL_AGENT_MODEL,
+      messages: [
+        {
+          role: "user",
+          content: logoPrompt,
+        },
+      ],
+    });
 
-    // Extract the SVG code from the response
+    console.log("Logo API Raw Response (Anthropic):", logoMessage);
+    console.log(
+      "Logo API Raw Response (Mistral):",
+      mistralResponse.choices[0].message.content
+    );
+
+    // Extract the SVG code from the Anthropic response
     const svgCode = Array.isArray(logoMessage.content)
       ? logoMessage.content
           .filter((block) => block.type === "text")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
+        "@mistralai/mistralai": "^1.5.1",
         "framer-motion": "^12.5.0",
         "next": "^14.2.15",
         "next-themes": "^0.3.0",
@@ -131,6 +132,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.5.1.tgz",
+      "integrity": "sha512-Ie0EH4dAO11MEXR5N2kS2cgr+ycTWvqN/yP9bKrtmUEqjdcF4i7DLxtrFMUw5l2dOPhrkX93G4SziFiATPWu2w==",
+      "dependencies": {
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "zod": ">= 3"
       }
     },
     "node_modules/@next/env": {
@@ -2391,6 +2403,25 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.4",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.4.tgz",
+      "integrity": "sha512-0uNlcvgabyrni9Ag8Vghj21drk7+7tp7VTwwR7KxxXXc/3pbXz2PHlDgj3cICahgF1kHm4dExBFj7BXrZJXzig==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
+    "@mistralai/mistralai": "^1.5.1",
     "framer-motion": "^12.5.0",
     "next": "^14.2.15",
     "next-themes": "^0.3.0",


### PR DESCRIPTION
This PR merged the mistral endpoint for producing SVG logo's that prints to console and also has a new dependency as mistralai for npm